### PR TITLE
Minor Fix for the Page Jumping around when zooming

### DIFF
--- a/KomgaZoom.user.js
+++ b/KomgaZoom.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Komga Zoom
 // @namespace    https://github.com/wanestar/KomgaZoom
-// @version      1.1
+// @version      1.1.1
 // @description  Add efficient image resizing buttons to Komga reader view without slowing down large books
 // @match        http://192.168.1.X:25600/* 
 // @grant        none
@@ -9,6 +9,7 @@
 // ==/UserScript==
 
 //IMPORTANT! Enter the IP ADDRESS of your server above in the @MATCH. Keep the /* !!
+
 
 (function () {
     'use strict';
@@ -41,22 +42,42 @@
         }
     }
 
-    function updateZoom(factor) {
-        zoomLevel *= factor;
-        const images = document.querySelectorAll('img');
-        images.forEach(img => {
-            if (!img.dataset.originalWidth || !img.dataset.originalHeight) {
-                img.dataset.originalWidth = img.naturalWidth || img.width;
-                img.dataset.originalHeight = img.naturalHeight || img.height;
-            }
+function updateZoom(factor) {
+    zoomLevel *= factor;
 
-            const newWidth = parseFloat(img.dataset.originalWidth) * zoomLevel;
-            const newHeight = parseFloat(img.dataset.originalHeight) * zoomLevel;
+    // Try to find the currently visible page number label
+    const currentPageLabel = document.querySelector('.v-label.theme--dark');
+    const currentPageNum = currentPageLabel ? parseInt(currentPageLabel.textContent.trim()) : null;
 
-            img.style.width = `${newWidth}px`;
-            img.style.height = `${newHeight}px`;
+    // Find the image closest to that page number (Komga loads images in order)
+    const images = Array.from(document.querySelectorAll('img'));
+    const targetImg = currentPageNum ? images[currentPageNum - 1] : null;
+
+    const offsetBefore = targetImg ? targetImg.getBoundingClientRect().top : 0;
+
+    images.forEach(img => {
+        if (!img.dataset.originalWidth || !img.dataset.originalHeight) {
+            img.dataset.originalWidth = img.naturalWidth || img.width;
+            img.dataset.originalHeight = img.naturalHeight || img.height;
+        }
+
+        const newWidth = parseFloat(img.dataset.originalWidth) * zoomLevel;
+        const newHeight = parseFloat(img.dataset.originalHeight) * zoomLevel;
+
+        img.style.width = `${newWidth}px`;
+        img.style.height = `${newHeight}px`;
+    });
+
+    // After resizing, scroll back to the same image position
+    if (targetImg) {
+        requestAnimationFrame(() => {
+            const offsetAfter = targetImg.getBoundingClientRect().top;
+            const scrollDiff = offsetAfter - offsetBefore;
+            window.scrollBy({ top: scrollDiff });
         });
     }
+}
+
 
     // Debounced observer to reduce CPU usage
     let debounceTimer;


### PR DESCRIPTION
- Added logic to track currently visible page number before zoom
- Anchored scroll position to the correct image after resizing to prevent jump